### PR TITLE
DO-1197: Additional parameters - Preferred Alert Name and Alert Threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It will ask a few parameters including:
 ### Headless Mode
 You can run a one-liner by specifying all the arguments required:
 
-`docker run --rm -it --volume ~/.aws:/home/node/.aws aligent/cdk-cloudwatch-rds-alert --profile <AWS_PROFILE> --rds-instances <RDS_INSTANCE_ID> --security-group <SECURITY_GROUP> --slack-webhook-url-ssm <AWS_SSM_PARAMETER_FOR_SLACK_WEBHOOK_URL> --slack-channel <SLACK_CHANNEL> [--slack-username <SLACK_USERNAME>]`
+`docker run --rm -it --volume ~/.aws:/home/node/.aws aligent/cdk-cloudwatch-rds-alert --profile <AWS_PROFILE> --rds-instances <RDS_INSTANCE_IDS> --security-group <SECURITY_GROUP> --slack-webhook-url-ssm <AWS_SSM_PARAMETER_FOR_SLACK_WEBHOOK_URL> --slack-channel <SLACK_CHANNEL> [--slack-username <SLACK_USERNAME>] [--rds-preferred-names <RDS_INSTANCE_PREFERRED_NAMES>] [--cpu-alert-threshold <THRESHOLD_PER_CENT>]`
 
 *Note: if you run the command once again against the same account with different parameters, the existing stack will be overwritten.*
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ if [[ $# -gt 0 ]]; then # Headless mode
         echo "Optional arguments:"
         echo -e "\t --slack-username SLACK_USERNAME (default: RDSAlert)"
         echo -e "\t --rds-preferred-name RDS_INSTANCE_PREFERRED_NAMES (example: Production_DB,Preprod_DB)"
-        echo -e "\t --cpu-alert-threshold SLACK_USERNAME (default: 30 per cent)"
+        echo -e "\t --cpu-alert-threshold CPU_PERCENTAGE (default: 30 per cent)"
         exit 1
     fi
 else # Interactive Mode


### PR DESCRIPTION
- Use a chosen preferred name for alert instead of instance ID (optional, default: instance ID)
- Enable choosing alerting threshold (optional, default: 30%)

The number of instance ID's and corresponding preferred names, when more than one are provided, is compared at stack deploying step rather than the runtime Lambda function as it's when they are defined.